### PR TITLE
[metrics] fixed growth to update properly on page refresh

### DIFF
--- a/api/metrics/user_growth.go
+++ b/api/metrics/user_growth.go
@@ -12,12 +12,30 @@ func UserGrowth(svc *UserMetricsService) gin.HandlerFunc {
 	// it needs to be initialized at the server
 	logs.Init("initializing service handler [%s.%s]", svc.endpoint, svc.version)
 	return func(c *gin.Context) {
+		err := svc.UpdateTotalUsers()
+		if err != nil {
+			logs.Err("failed to get user count: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to get user count",
+			})
+			return
+		}
+		err = svc.UpdateRoleCounts()
+		if err != nil {
+			logs.Err("failed to get user count by role: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to get user count by role",
+			})
+			return
+		}
+		service.AddGrowthData()
+		service.WriteMetrics()
 		svc.mu.Lock()
-		total_users := svc.total_users
-		total_roles := svc.total_roles
+		defer svc.mu.Unlock()
+
 		users_over_time_points := MapTimestampToInt64Points(svc.users_over_time)
-		logs.Info("total users: %d, total roles: %v", total_users, total_roles)
-		if total_users == 0 {
+		logs.Info("total users: %d, total roles: %v", svc.total_users, svc.total_roles)
+		if svc.total_users == 0 {
 			logs.Warn("no users found, returning empty metrics")
 			c.JSON(http.StatusOK, gin.H{
 				"total_users":     0,
@@ -25,16 +43,14 @@ func UserGrowth(svc *UserMetricsService) gin.HandlerFunc {
 				"users_over_time": []Point{},
 				"message":         "no users found",
 			})
-			svc.mu.Unlock()
 			return
 		}
-		svc.mu.Unlock()
 
 		logs.Debug("service: %+v", svc)
 
 		c.JSON(http.StatusOK, gin.H{
-			"total_users":     total_users,
-			"total_roles":     total_roles,
+			"total_users":     svc.total_users,
+			"total_roles":     svc.total_roles,
 			"users_over_time": users_over_time_points,
 			"message":         "user metrics retrieved successfully",
 		})


### PR DESCRIPTION
the user growth handler now correctly updates all of the data every call, rather than just reading whatever state the service is currently in